### PR TITLE
fix for new game versions with openxr and new link app folder path

### DIFF
--- a/OcuFix/OcuFix/Configuration/PluginConfig.cs
+++ b/OcuFix/OcuFix/Configuration/PluginConfig.cs
@@ -12,7 +12,7 @@ namespace OcuFix.Configuration
         public virtual bool SetPriority { get; set; } = true;
         public virtual bool Restore { get; set; } = true;
         public virtual bool GamePriority { get; set; } = true;
-        public virtual string DebugToolPath { get; set; } = @"C:\Program Files\Oculus\Support\oculus-diagnostics\OculusDebugToolCLI.exe";
+        public virtual string DebugToolPath { get; set; } = @"%OculusBase%\Support\oculus-diagnostics\OculusDebugToolCLI.exe";
         public virtual bool EnableChecks { get; set; } = true;
 
         public virtual void OnReload()

--- a/OcuFix/OcuFix/DebugToolControl.cs
+++ b/OcuFix/OcuFix/DebugToolControl.cs
@@ -40,7 +40,7 @@ namespace OcuFix
 
             File.WriteAllText(CommandTempFile, command + "\r\nexit\r\n");
 
-            var debugToolPath = Configuration.PluginConfig.Instance.DebugToolPath;
+            var debugToolPath = Environment.ExpandEnvironmentVariables(Configuration.PluginConfig.Instance.DebugToolPath); //fixes the check after changing debugToolPath to have %OculusBase%
             if (!File.Exists(debugToolPath))
                 throw new Exception("Debug tool path is invalid!");
 

--- a/OcuFix/OcuFix/OcuFix.csproj
+++ b/OcuFix/OcuFix/OcuFix.csproj
@@ -40,66 +40,70 @@
     <DisableZipRelease>True</DisableZipRelease>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BSML">
-      <HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Main">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="HMLib">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMLib.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="HMUI">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMUI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="IPA.Loader">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Unity.TextMeshPro">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.UI">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.UIElementsModule">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UIElementsModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.UIModule">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UIModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.VRModule">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.VRModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.XRModule">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.XRModule.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
+      <Reference Include="BSML">
+        <HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
+        <Private>False</Private>
+        <SpecificVersion>False</SpecificVersion>
+      </Reference>
+      <Reference Include="HMLib">
+        <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMLib.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="HMUI">
+        <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMUI.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="IPA.Loader">
+        <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="Main">
+        <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="System" />
+      <Reference Include="System.Core" />
+      <Reference Include="System.Data" />
+      <Reference Include="System.Data.DataSetExtensions" />
+      <Reference Include="System.Xml" />
+      <Reference Include="System.Xml.Linq" />
+      <Reference Include="Unity.TextMeshPro">
+        <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="Unity.XR.OpenXR">
+          <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.XR.OpenXR.dll</HintPath>
+          <Private>false</Private>
+      </Reference>
+      <Reference Include="UnityEngine">
+        <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="UnityEngine.CoreModule">
+        <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="UnityEngine.UI">
+        <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UI.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="UnityEngine.UIElementsModule">
+        <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UIElementsModule.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="UnityEngine.UIModule">
+        <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="UnityEngine.VRModule">
+        <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.VRModule.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="UnityEngine.XRModule">
+        <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.XRModule.dll</HintPath>
+        <Private>False</Private>
+        <SpecificVersion>False</SpecificVersion>
+      </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AswHelper.cs" />

--- a/OcuFix/OcuFix/Plugin.cs
+++ b/OcuFix/OcuFix/Plugin.cs
@@ -28,12 +28,6 @@ namespace OcuFix
                 return true;
             }
 
-            if (Environment.CommandLine.ToLower().Contains("fpfc") && PluginConfig.Instance.EnableChecks)
-            {
-                Plugin.Log.Warn("FPFC mode enabled, ignoring");
-                return true;
-            }
-
             return false;
         }
 

--- a/OcuFix/OcuFix/Plugin.cs
+++ b/OcuFix/OcuFix/Plugin.cs
@@ -19,12 +19,13 @@ namespace OcuFix
     {
         internal static Plugin Instance { get; private set; }
         internal static IPALogger Log { get; private set; }
+        internal static VRPlatformSDK VRPlatformSDK { get; }
 
         private bool ShouldIgnore()
         {
-            if (!XRSettings.loadedDeviceName.ToLower().Contains("oculus") && PluginConfig.Instance.EnableChecks)
+            if (VRPlatformSDK is VRPlatformSDK.Oculus && PluginConfig.Instance.EnableChecks)
             {
-                Plugin.Log.Warn("Oculus vrmode not set, ignoring");
+                Plugin.Log.Warn("OpenXR runtime is not oculus, ignoring");
                 return true;
             }
 
@@ -44,7 +45,6 @@ namespace OcuFix
             Log = logger;
 
             PluginConfig.Instance = config.Generated<PluginConfig>();
-            BSMLSettings.instance.AddSettingsMenu("OcuFix", "OcuFix.Views.Settings.bsml", Configuration.PluginConfig.Instance);
         }
 
         [OnStart]
@@ -55,6 +55,12 @@ namespace OcuFix
 
             AswHelper.DisableAswWrapper();
             ProcessPriorityHelper.SwapPrioritiesWrapper();
+            BeatSaberMarkupLanguage.Util.MainMenuAwaiter.MainMenuInitializing += MainMenuInit;
+        }
+        
+        public void MainMenuInit()
+        {
+            BSMLSettings.Instance.AddSettingsMenu("OcuFix", "OcuFix.Views.Settings.bsml", PluginConfig.Instance);
         }
 
         [OnExit]

--- a/OcuFix/OcuFix/Plugin.cs
+++ b/OcuFix/OcuFix/Plugin.cs
@@ -9,7 +9,7 @@ using BeatSaberMarkupLanguage.Settings;
 using OcuFix.Configuration;
 using UnityEngine;
 using UnityEngine.SceneManagement;
-using UnityEngine.XR;
+using UnityEngine.XR.OpenXR;
 using IPALogger = IPA.Logging.Logger;
 
 namespace OcuFix
@@ -19,13 +19,12 @@ namespace OcuFix
     {
         internal static Plugin Instance { get; private set; }
         internal static IPALogger Log { get; private set; }
-        internal static VRPlatformSDK VRPlatformSDK { get; }
 
         private bool ShouldIgnore()
         {
-            if (VRPlatformSDK is VRPlatformSDK.Oculus && PluginConfig.Instance.EnableChecks)
+            if (!OpenXRRuntime.name.Contains("Oculus") && PluginConfig.Instance.EnableChecks)
             {
-                Plugin.Log.Warn("OpenXR runtime is not oculus, ignoring");
+                Plugin.Log.Warn("OpenXR runtime is not Oculus, ignoring");
                 return true;
             }
 

--- a/OcuFix/OcuFix/ProcessPriorityHelper.cs
+++ b/OcuFix/OcuFix/ProcessPriorityHelper.cs
@@ -20,6 +20,7 @@ namespace OcuFix
             }
         }
 
+       /* oculus-platform-runtime only does entitlement checks for the oculus store version of beat saber, no need to have it on AboveNormal priority
         private static ProcessPriorityClass _targetRuntimePriorityClass = ProcessPriorityClass.AboveNormal;
         private static void SwapRuntime()
         {
@@ -33,7 +34,7 @@ namespace OcuFix
                 (runtimeProcess.PriorityClass, _targetRuntimePriorityClass) = (_targetRuntimePriorityClass, runtimeProcess.PriorityClass);
                 Plugin.Log.Info("Runtime priority set");
             }
-        }
+        }*/
 
         private static ProcessPriorityClass _targetServerPriorityClass = ProcessPriorityClass.AboveNormal;
         private static void SwapServer()
@@ -57,7 +58,7 @@ namespace OcuFix
 
             if (Configuration.PluginConfig.Instance.SetPriority)
             {
-                SwapRuntime();
+                //SwapRuntime();
                 SwapServer();
             }
         }

--- a/OcuFix/OcuFix/Properties/AssemblyInfo.cs
+++ b/OcuFix/OcuFix/Properties/AssemblyInfo.cs
@@ -15,5 +15,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("fe8574f7-b6a0-4eca-a846-0ba32fd86806")]
-[assembly: AssemblyVersion("0.1.0")]
-[assembly: AssemblyFileVersion("0.1.0")]
+[assembly: AssemblyVersion("0.1.1")]
+[assembly: AssemblyFileVersion("0.1.1")]

--- a/OcuFix/OcuFix/manifest.json
+++ b/OcuFix/OcuFix/manifest.json
@@ -3,12 +3,12 @@
   "id": "OcuFix",
   "name": "OcuFix",
   "author": "Otiosum",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
-  "gameVersion": "1.23.0",
+  "gameVersion": "1.40.8",
   "dependsOn": {
     "BSIPA": "^4.2.1",
-    "BeatSaberMarkupLanguage": "^1.6.1"
+    "BeatSaberMarkupLanguage": "^1.12.5"
   },
   "features": []
 }

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ A BSIPA compatible mod that can automatically disable ASW (Asynchronous Spacewar
 ![screenshot](screenshot.png)
 
 ## Installation
-Make sure that you have core mods installed with [ModAssistant](https://github.com/Assistant/ModAssistant) (BSIPA, BSML). Go to the [releases page](https://github.com/SamuelTulach/OcuFix/releases) and download the latest build (or build compatible with your Beat Saber version). Extract the zip file and move the DLL file into plugins folder located in Beat Saber install directory.
+Make sure that you have core mods installed with [BSManager](https://github.com/Zagrios/bs-manager) (BSIPA, BSML). Go to the [releases page](https://github.com/SamuelTulach/OcuFix/releases) and download the latest build (or build compatible with your Beat Saber version). Extract the zip file and move the DLL file into plugins folder located in Beat Saber install directory.
 
 ## Usage
-There is not much configuration that you have to do. If you have installed Oculus software to default install location, you can just install the mod and stop caring about it. If you have installed it to a custom location, please change the Oculus Debug Tool CLI path in the plugin configuration (should be OcuFix.json in UserData). Make sure that it's a full path and that it properly escapes characters. Bellow you can see an example default config:
+There is not much configuration that you have to do. If you have the debug tool in its default install location, you can just install the mod and stop caring about it. Otherwise, please change the Oculus Debug Tool CLI path in the plugin configuration (OcuFix.json in UserData). Make sure that it's a full path and that it properly escapes characters. Bellow you can see an example default config:
 
     {
         "DisableASW": true,
         "SetPriority": true,
         "Restore": true,
         "GamePriority": true,
-        "DebugToolPath": "C:\\Program Files\\Oculus\\Support\\oculus-diagnostics\\OculusDebugToolCLI.exe",
+        "DebugToolPath": "%OculusBase%\\Support\\oculus-diagnostics\\OculusDebugToolCLI.exe",
         "EnableChecks": false
     }
 


### PR DESCRIPTION
cant reopen the old pr for some reason and i thought its best to leave it open just so theres something to compete with the vibe coded ones
oculus-platform-runtime doesnt affect the ingame performance so i removed the priority swap for that specific process (the thing it actually does is entitlement checks for games bought in oculus store)